### PR TITLE
fix: count_mono now preserves NA in compositions

### DIFF
--- a/R/count-mono.R
+++ b/R/count-mono.R
@@ -83,6 +83,10 @@ count_mono.glyrepr_composition <- function(x, mono = NULL, include_subs = FALSE)
 
   # Count the number of monosaccharides or substituents
   count_one <- function(one_mono, mono) {
+    # Handle NULL elements (NA compositions) - return NA for them
+    if (is.null(one_mono) || length(one_mono) == 0) {
+      return(NA_integer_)
+    }
     if (mono %in% names(one_mono)) {
       n <- one_mono[[mono]]
       if (is.na(n)) {

--- a/tests/testthat/test-count-mono.R
+++ b/tests/testthat/test-count-mono.R
@@ -100,16 +100,33 @@ test_that("count_mono works for substituents", {
 })
 
 test_that("count_mono preserves NA in compositions", {
-  # Composition with NA element
+  # Composition with NA element - total count (mono = NULL)
   comps <- glycan_composition(c(Gal = 1), NA)
   expect_equal(count_mono(comps), c(1L, NA_integer_))
 
-  # NA in different positions
+  # NA in different positions - total count
   comps2 <- glycan_composition(NA, c(Gal = 1))
   expect_equal(count_mono(comps2), c(NA_integer_, 1L))
 
   comps3 <- glycan_composition(c(Gal = 1), NA, c(GlcNAc = 2))
   expect_equal(count_mono(comps3), c(1L, NA_integer_, 2L))
+
+  # Composition with NA element - specific mono count
+  comps4 <- glycan_composition(c(Gal = 1), NA)
+  expect_equal(count_mono(comps4, "Gal"), c(1L, NA_integer_))
+  expect_equal(count_mono(comps4, "Hex"), c(1L, NA_integer_))
+  expect_equal(count_mono(comps4, "Glc"), c(0L, NA_integer_))
+
+  # NA in different positions - specific mono count
+  comps5 <- glycan_composition(NA, c(Gal = 1, GlcNAc = 1))
+  expect_equal(count_mono(comps5, "Gal"), c(NA_integer_, 1L))
+  expect_equal(count_mono(comps5, "HexNAc"), c(NA_integer_, 1L))
+  expect_equal(count_mono(comps5, "Man"), c(NA_integer_, 0L))
+
+  # Multiple NAs - specific mono count
+  comps6 <- glycan_composition(c(Gal = 1), NA, c(GlcNAc = 2), NA)
+  expect_equal(count_mono(comps6, "Gal"), c(1L, NA_integer_, 0L, NA_integer_))
+  expect_equal(count_mono(comps6, "HexNAc"), c(0L, NA_integer_, 2L, NA_integer_))
 })
 
 # Tests for count_mono with glycan structures ----------------------------


### PR DESCRIPTION
## Summary
- Fix bug where `count_mono()` returned `0` instead of `NA` for compositions with NA elements
- When counting monosaccharides in compositions with NA elements, the function now correctly returns NA instead of 0

## Test plan
- All 948 tests pass
- New test `count_mono preserves NA in compositions` added

🤖 Generated with [Claude Code](https://claude.com/claude-code)