### PR TITLE
fix: vctrs_vctr class duplication in glyrepr_structure objects (#30)

### DIFF
--- a/R/structure.R
+++ b/R/structure.R
@@ -632,7 +632,7 @@ vec_restore.glyrepr_structure <- function(x, to, ...) {
 
   # If prototype has no graphs, return with empty graphs
   if (length(graphs) == 0) {
-    out <- vctrs::new_vctr(x, graphs = list(), class = class(to))
+    out <- vctrs::new_vctr(x, graphs = list(), class = "glyrepr_structure")
     return(out)
   }
 
@@ -641,7 +641,7 @@ vec_restore.glyrepr_structure <- function(x, to, ...) {
 
   # If x is empty (e.g., during vec_ptype2), keep all graphs from prototype
   if (length(iupacs) == 0) {
-    out <- vctrs::new_vctr(x, graphs = graphs, class = class(to))
+    out <- vctrs::new_vctr(x, graphs = graphs, class = "glyrepr_structure")
     return(out)
   }
 
@@ -652,7 +652,7 @@ vec_restore.glyrepr_structure <- function(x, to, ...) {
   # Remove any NULL elements (can happen with empty list indexing)
   used_graphs <- used_graphs[!vapply(used_graphs, is.null, logical(1))]
 
-  out <- vctrs::new_vctr(x, graphs = used_graphs, class = class(to))
+  out <- vctrs::new_vctr(x, graphs = used_graphs, class = "glyrepr_structure")
   out
 }
 

--- a/tests/testthat/test-structure.R
+++ b/tests/testthat/test-structure.R
@@ -1677,3 +1677,63 @@ test_that("count_mono handles single valid structure", {
   expect_equal(length(count), 1)
   expect_false(is.na(count))
 })
+
+# Tests for class duplication fix (issue #30) -------------------------------------
+
+test_that("class is not duplicated after c()", {
+  g1 <- o_glycan_core_1()
+  g2 <- n_glycan_core()
+
+  # Individual structures should have correct class
+  expect_true(inherits(g1, "glyrepr_structure"))
+  expect_equal(sum(class(g1) == "vctrs_vctr"), 1)
+  expect_true(inherits(g2, "glyrepr_structure"))
+  expect_equal(sum(class(g2) == "vctrs_vctr"), 1)
+
+  # After c(), class should still be correct (not duplicated)
+  combined <- c(g1, g2)
+  expect_true(inherits(combined, "glyrepr_structure"))
+  expect_equal(sum(class(combined) == "vctrs_vctr"), 1)
+  expect_equal(length(unique(class(combined))), length(class(combined)))
+})
+
+test_that("class is not duplicated after subsetting", {
+  glycans <- c(o_glycan_core_1(), n_glycan_core())
+
+  # Before subsetting
+  expect_true(inherits(glycans, "glyrepr_structure"))
+  expect_equal(sum(class(glycans) == "vctrs_vctr"), 1)
+  expect_equal(length(unique(class(glycans))), length(class(glycans)))
+
+  # After subsetting
+  subset1 <- glycans[1]
+  expect_true(inherits(subset1, "glyrepr_structure"))
+  expect_equal(sum(class(subset1) == "vctrs_vctr"), 1)
+  expect_equal(length(unique(class(subset1))), length(class(subset1)))
+
+  subset2 <- glycans[c(1, 2)]
+  expect_true(inherits(subset2, "glyrepr_structure"))
+  expect_equal(sum(class(subset2) == "vctrs_vctr"), 1)
+  expect_equal(length(unique(class(subset2))), length(class(subset2)))
+
+  subset_empty <- glycans[integer(0)]
+  expect_true(inherits(subset_empty, "glyrepr_structure"))
+  expect_equal(sum(class(subset_empty) == "vctrs_vctr"), 1)
+  expect_equal(length(unique(class(subset_empty))), length(class(subset_empty)))
+})
+
+test_that("vec_restore does not duplicate class", {
+  g1 <- o_glycan_core_1()
+  g2 <- n_glycan_core()
+
+  ptype <- vctrs::vec_ptype2(g1, g2)
+  # Prototype should have correct class
+  expect_true(inherits(ptype, "glyrepr_structure"))
+  expect_equal(sum(class(ptype) == "vctrs_vctr"), 1)
+
+  # vec_restore should not duplicate class
+  restored <- vctrs::vec_restore(g1, ptype)
+  expect_true(inherits(restored, "glyrepr_structure"))
+  expect_equal(sum(class(restored) == "vctrs_vctr"), 1)
+  expect_equal(length(unique(class(restored))), length(class(restored)))
+})


### PR DESCRIPTION
## Summary

Fixes issue #30 where subsetting a `glyrepr_structure` object caused the `vctrs_vctr` class to be duplicated.

### Root Cause

The `vec_restore.glyrepr_structure` function was passing `class(to)` to `vctrs::new_vctr()`. When `to` had class `c("glyrepr_structure", "vctrs_vctr")`, calling `vctrs::new_vctr()` with this class caused vctrs to add another `vctrs_vctr` internally, resulting in duplicated classes.

### Fix

Changed `vec_restore.glyrepr_structure` in `R/structure.R:629-657` to pass only `"glyrepr_structure"` instead of `class(to)` to `vctrs::new_vctr()`. The vctrs package automatically adds its base `vctrs_vctr` class, so we only need to specify our custom class.

### Changes Made

- **R/structure.R**: Fixed `vec_restore.glyrepr_structure` to use `class = "glyrepr_structure"` instead of `class = class(to)`
- **tests/testthat/test-structure.R**: Added regression tests for the class duplication issue

### Test Plan

- All 1135 tests pass
- New regression tests verify class is not duplicated after `c()` and subsetting operations

🤖 Generated with [Claude Code](https://claude.com/claude-code)