### PR TITLE
fix: glycan_composition works with duplicated inputs

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,9 @@
 # glyrepr (development version)
 
+## Minor improvements and bug fixes
+
+* Fix the bug that `glycan_composition()` and `as_glycan_composition()` cannot handle duplications in the input. For example, `as_glycan_composition("Hex(2)Hex(1)HexNAc(2)")` is correctly regared as `Hex(3)HexNAc(2)` now.
+
 # glyrepr 0.10.1
 
 ## Minor improvements and bug fixes

--- a/R/composition.R
+++ b/R/composition.R
@@ -649,10 +649,9 @@ parse_single_composition <- function(char) {
 #' @noRd
 .aggregate_composition_components <- function(components) {
   component_names <- unique(names(components))
-  aggregated <- purrr::map_int(
-    component_names,
-    ~ sum(components[names(components) == .x])
-  )
+  groups <- factor(names(components), levels = component_names)
+  aggregated <- tapply(components, groups, sum)
+  aggregated <- as.integer(aggregated)
   names(aggregated) <- component_names
   aggregated
 }

--- a/R/composition.R
+++ b/R/composition.R
@@ -20,7 +20,8 @@
 #'
 #' Components are automatically sorted with monosaccharides first (according to
 #' their order in the monosaccharides table), followed by substituents (according
-#' to their order in `available_substituents()`).
+#' to their order in `available_substituents()`). Duplicate components are
+#' automatically summed.
 #'
 #' @examples
 #' # A vector with one composition (generic monosaccharides)
@@ -61,6 +62,7 @@ glycan_composition <- function(...) {
     if (is.null(.x)) return(.x)
     result <- as.integer(.x)
     names(result) <- names(.x)
+    result <- .aggregate_composition_components(result)
     .reorder_composition_components(result)
   })
 
@@ -634,6 +636,25 @@ parse_single_composition <- function(char) {
   sub_orders <- available_substituents()
   orders <- c(mono_orders, sub_orders)
   components[order(match(names(components), orders))]
+}
+
+#' Aggregate duplicated composition components
+#'
+#' Components with the same name are summed while preserving the first occurrence
+#' of each component name. The final display order is handled separately by
+#' `.reorder_composition_components()`.
+#'
+#' @param components A named integer vector of composition components.
+#' @returns A named integer vector with unique component names.
+#' @noRd
+.aggregate_composition_components <- function(components) {
+  component_names <- unique(names(components))
+  aggregated <- purrr::map_int(
+    component_names,
+    ~ sum(components[names(components) == .x])
+  )
+  names(aggregated) <- component_names
+  aggregated
 }
 
 # Helper function to format a subset of compositions

--- a/man/glycan_composition.Rd
+++ b/man/glycan_composition.Rd
@@ -34,7 +34,8 @@ generic or concrete monosaccharides.
 
 Components are automatically sorted with monosaccharides first (according to
 their order in the monosaccharides table), followed by substituents (according
-to their order in \code{available_substituents()}).
+to their order in \code{available_substituents()}). Duplicate components are
+automatically summed.
 }
 \examples{
 # A vector with one composition (generic monosaccharides)

--- a/tests/testthat/test-composition.R
+++ b/tests/testthat/test-composition.R
@@ -53,6 +53,11 @@ test_that("glycan_composition rejects empty compositions", {
   expect_error(glycan_composition(integer(0)), "at least one residue")
 })
 
+test_that("glycan_composition deals with duplications", {
+  comp <- glycan_composition(c(Hex = 1, HexNAc = 1, Hex = 2))
+  expect_equal(as.character(comp), "Hex(3)HexNAc(1)")
+})
+
 test_that("as_glycan_composition works with list of named vectors", {
   vec_list <- list(c(Hex = 5, HexNAc = 2), c(Hex = 3, HexNAc = 1))
   comp <- as_glycan_composition(vec_list)
@@ -291,6 +296,11 @@ test_that("as_glycan_composition reorder residues", {
   comp <- as_glycan_composition(chars)
   expected <- c("Hex(2)HexNAc(1)", "Hex(2)HexNAc(1)")
   expect_equal(format(comp), expected)
+})
+
+test_that("as_glycan_composition works for duplications", {
+  comp <- as_glycan_composition("Hex(2)Hex(3)HexNAc(1)HexNAc(2)")
+  expect_equal(as.character(comp), "Hex(5)HexNAc(3)")
 })
 
 test_that("as.character works for compositions", {


### PR DESCRIPTION
## Summary

Fix `glycan_composition()` and `as_glycan_composition()` to properly handle duplicated residue inputs by merging them into single entries.

## Changes

- `R/composition.R`: Merge duplicated residues in `glycan_composition()` and `as_glycan_composition()`
- `tests/testthat/test-composition.R`: Add tests for duplicated inputs

Closes #38