### PR TITLE
Add support for E and L Neu5Ac codes in glycan composition parsing

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,9 @@
 # glyrepr (development version)
 
+## New features
+
+* `as_glycan_composition()` now supports parsing "E" and "L" in the input composition strings as "NeuAc". For example, `as_glycan_composition("H5N4F1L1E1")` is now correctly parsed as `Hex(5)HexNAc(4)Fuc(1)NeuAc(2)`, with a warning about dropping the sialic acid linkage information.
+
 ## Minor improvements and bug fixes
 
 * Fix the bug that `glycan_composition()` and `as_glycan_composition()` cannot handle duplications in the input. For example, `as_glycan_composition("Hex(2)Hex(1)HexNAc(2)")` is correctly regared as `Hex(3)HexNAc(2)` now (#40).

--- a/R/composition.R
+++ b/R/composition.R
@@ -98,6 +98,12 @@ is_glycan_composition <- function(x) {
 #' vertex in the structure. For example, a vertex with `sub = "3Me"`
 #' contributes one "Me" substituent to the composition.
 #'
+#' Simple composition strings use one-letter residue codes: "H" for "Hex",
+#' "N" for "HexNAc", "F" for "dHex", "S"/"A" for "NeuAc", and "G" for
+#' "NeuGc". "E" and "L" are also accepted as linkage-specific Neu5Ac codes;
+#' they are converted to "NeuAc" with a warning because composition objects do
+#' not preserve linkage information.
+#'
 #' @examples
 #' # From a single named vector
 #' as_glycan_composition(c(Hex = 5, HexNAc = 2))
@@ -200,6 +206,7 @@ vec_cast.glyrepr_composition.character <- function(x, to, ...) {
       }
 
       compositions <- purrr::map(parse_result, "composition")
+      .warn_lossy_neuac_linkage(parse_result)
     }
 
     # Build result list preserving order - no global state needed
@@ -227,6 +234,7 @@ vec_cast.glyrepr_composition.character <- function(x, to, ...) {
       "i" = "Expected format: 'Hex(5)HexNAc(2)' with monosaccharide names followed by counts in parentheses."
     ))
   }
+  .warn_lossy_neuac_linkage(parse_result)
   if (length(compositions) == 0) {
     return(glycan_composition())
   }
@@ -530,7 +538,13 @@ parse_single_composition <- function(char) {
     result <- tryCatch(
       {
         composition <- parser(char)
-        list(composition = composition, valid = TRUE)
+        lossy_neuac_linkage <- isTRUE(attr(composition, "lossy_neuac_linkage"))
+        attr(composition, "lossy_neuac_linkage") <- NULL
+        list(
+          composition = composition,
+          valid = TRUE,
+          lossy_neuac_linkage = lossy_neuac_linkage
+        )
       },
       error = function(e) NULL
     )
@@ -541,6 +555,19 @@ parse_single_composition <- function(char) {
 
   # All parsers failed
   list(composition = NULL, valid = FALSE)
+}
+
+#' Warn when simple NeuAc linkage codes are converted to composition counts
+#' @param parse_result A list returned by `parse_single_composition()`.
+#' @returns Nothing. Called for its warning side effect.
+#' @noRd
+.warn_lossy_neuac_linkage <- function(parse_result) {
+  if (purrr::some(parse_result, ~ isTRUE(.x$lossy_neuac_linkage))) {
+    cli::cli_warn(c(
+      "Simple composition codes {.val E} and {.val L} are parsed as {.val NeuAc}.",
+      "i" = "Linkage-specific Neu5Ac information is discarded in glycan compositions."
+    ))
+  }
 }
 
 .parse_byonic_comp <- function(x) {
@@ -579,7 +606,7 @@ parse_single_composition <- function(char) {
 
 .parse_simple_comp <- function(x) {
   # "S" and "A" are both NeuAc, "G" is NeuGc
-  mono_pattern <- "([HNFSAG])(\\d+)"
+  mono_pattern <- "([HNFSAGEL])(\\d+)"
   matches <- stringr::str_extract_all(x, mono_pattern, simplify = FALSE)[[1]]
 
   # Check if no monos were matched
@@ -602,12 +629,15 @@ parse_single_composition <- function(char) {
   })
 
   mono_names <- purrr::map_chr(parsed_matches, "name")
+  lossy_neuac_linkage <- any(mono_names %in% c("E", "L"))
   mono_names <- dplyr::recode_values(mono_names,
     "H" ~ "Hex",
     "N" ~ "HexNAc",
     "F" ~ "dHex",
     "S" ~ "NeuAc",
     "A" ~ "NeuAc",
+    "E" ~ "NeuAc",
+    "L" ~ "NeuAc",
     "G" ~ "NeuGc"
   )
   mono_counts <- purrr::map_int(parsed_matches, "count")
@@ -615,6 +645,7 @@ parse_single_composition <- function(char) {
   # Create named vector
   comp <- mono_counts
   names(comp) <- mono_names
+  attr(comp, "lossy_neuac_linkage") <- lossy_neuac_linkage
   comp
 }
 

--- a/R/composition.R
+++ b/R/composition.R
@@ -558,13 +558,14 @@ parse_single_composition <- function(char) {
 }
 
 #' Warn when simple NeuAc linkage codes are converted to composition counts
-#' @param parse_result A list returned by `parse_single_composition()`.
+#' @param parse_result A list of per-element results returned by
+#'   `parse_single_composition()`.
 #' @returns Nothing. Called for its warning side effect.
 #' @noRd
 .warn_lossy_neuac_linkage <- function(parse_result) {
   if (purrr::some(parse_result, ~ isTRUE(.x$lossy_neuac_linkage))) {
     cli::cli_warn(c(
-      "Simple composition codes {.val E} and {.val L} are parsed as {.val NeuAc}.",
+      "Simple composition codes {.val E} and/or {.val L} are parsed as {.val NeuAc}.",
       "i" = "Linkage-specific Neu5Ac information is discarded in glycan compositions."
     ))
   }

--- a/man/as_glycan_composition.Rd
+++ b/man/as_glycan_composition.Rd
@@ -30,6 +30,12 @@ When converting from glycan structures, both monosaccharides and substituents
 are counted. Substituents are extracted from the \code{sub} attribute of each
 vertex in the structure. For example, a vertex with \code{sub = "3Me"}
 contributes one "Me" substituent to the composition.
+
+Simple composition strings use one-letter residue codes: "H" for "Hex",
+"N" for "HexNAc", "F" for "dHex", "S"/"A" for "NeuAc", and "G" for
+"NeuGc". "E" and "L" are also accepted as linkage-specific Neu5Ac codes;
+they are converted to "NeuAc" with a warning because composition objects do
+not preserve linkage information.
 }
 \examples{
 # From a single named vector

--- a/tests/testthat/_snaps/composition.md
+++ b/tests/testthat/_snaps/composition.md
@@ -10,3 +10,12 @@
       2 Hex(2)HexNAc(1)     1
       3 Hex(3)dHex(1)       1
 
+# as_glycan_composition works for E and L
+
+    Code
+      comps <- as_glycan_composition(chars)
+    Condition
+      Warning:
+      Simple composition codes "E" and "L" are parsed as "NeuAc".
+      i Linkage-specific Neu5Ac information is discarded in glycan compositions.
+

--- a/tests/testthat/_snaps/composition.md
+++ b/tests/testthat/_snaps/composition.md
@@ -16,6 +16,6 @@
       comps <- as_glycan_composition(chars)
     Condition
       Warning:
-      Simple composition codes "E" and "L" are parsed as "NeuAc".
+      Simple composition codes "E" and/or "L" are parsed as "NeuAc".
       i Linkage-specific Neu5Ac information is discarded in glycan compositions.
 

--- a/tests/testthat/test-composition.R
+++ b/tests/testthat/test-composition.R
@@ -274,6 +274,17 @@ test_that("as_glycan_composition works for simple compositions", {
   expect_equal(as_glycan_composition(chars), expected)
 })
 
+test_that("as_glycan_composition works for E and L", {
+  chars <- c("H5N4E1", "H5N4L1", "H5N4E1L1")
+  expected <- glycan_composition(
+    c(Hex = 5, HexNAc = 4, NeuAc = 1),
+    c(Hex = 5, HexNAc = 4, NeuAc = 1),
+    c(Hex = 5, HexNAc = 4, NeuAc = 2)
+  )
+  expect_snapshot(comps <- as_glycan_composition(chars))  # should warn about E/L ambiguity
+  expect_equal(comps, expected)
+})
+
 # This test is replaced by tests for NA handling in character casting above
 
 test_that("as_glycan_composition works for empty characters", {


### PR DESCRIPTION
## Summary
- Accept `E` and `L` in simple composition strings and map them to `NeuAc`
- Emit a warning when linkage-specific Neu5Ac information is collapsed during composition parsing
- Add coverage for the new behavior and update the generated Rd/docs snapshot

## Testing
- `devtools::test(filter = "composition")` passed
- `devtools::test()` passed
- Verified the issue example parses to `Hex(6)HexNAc(6)NeuAc(2)` with the expected warning

Closes #39 