### PR TITLE
Update get_structure_level to return vector-wide levels

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,12 +1,12 @@
 # glyrepr (development version)
 
+## Breaking changes
+
+* `get_structure_level()` now returns one character scalar for a `glyrepr_structure` vector instead of one value per element. The vector-wide level is "intact", "partial", "topological", or "basic" according to the combined residue and linkage detail of the non-missing structures in the vector (#42).
+
 ## New features
 
 * `as_glycan_composition()` now supports parsing "E" and "L" in the input composition strings as "NeuAc". For example, `as_glycan_composition("H5N4F1L1E1")` is now correctly parsed as `Hex(5)HexNAc(4)Fuc(1)NeuAc(2)`, with a warning about dropping the sialic acid linkage information (#41).
-
-## Breaking changes
-
-* `get_structure_level()` now returns one character scalar for a `glyrepr_structure` vector instead of one value per element. The vector-wide level is "intact", "partial", "topological", or "basic" according to the combined residue and linkage detail of the non-missing structures in the vector.
 
 ## Minor improvements and bug fixes
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -4,12 +4,16 @@
 
 * `as_glycan_composition()` now supports parsing "E" and "L" in the input composition strings as "NeuAc". For example, `as_glycan_composition("H5N4F1L1E1")` is now correctly parsed as `Hex(5)HexNAc(4)Fuc(1)NeuAc(2)`, with a warning about dropping the sialic acid linkage information (#41).
 
+## Breaking changes
+
+* `get_structure_level()` now returns one character scalar for a `glyrepr_structure` vector instead of one value per element. The vector-wide level is "intact", "partial", "topological", or "basic" according to the combined residue and linkage detail of the non-missing structures in the vector.
+
 ## Minor improvements and bug fixes
 
 * Fix the bug that `glycan_composition()` and `as_glycan_composition()` cannot handle duplications in the input. For example, `as_glycan_composition("Hex(2)Hex(1)HexNAc(2)")` is correctly regared as `Hex(3)HexNAc(2)` now (#40).
 * `as_glycan_structure(NA_character_)` now creates a missing structure instead of erroring.
-* `get_structure_level()` now preserves missing structures as NA instead of treating them as "basic".
-* `reduce_structure_level()` skips missing structures when checking level ranks and preserves them in output.
+* `get_structure_level()` now ignores missing structures when determining the vector-wide level, and returns `NA_character_` for empty or all-missing structure vectors.
+* `reduce_structure_level()` preserves missing structures in output.
 * `simap()` and ``simap_structure()` now skip missing structures like the other smap variants.
 * `get_mono_type.glyrepr_composition()` now ignores missing composition elements and returns `NA_character_` for all-NA composition vectors.
 

--- a/R/structure-level.R
+++ b/R/structure-level.R
@@ -34,9 +34,9 @@ get_structure_level <- function(x) {
   non_na <- !structure_na_mask(x)
 
   if (!any(non_na)) {
-    if (length(x) == 0) {
-      return(NA_character_)
-    }
+    return(NA_character_)
+  }
+  if (length(x) == 0) {
     return(NA_character_)
   }
 

--- a/R/structure-level.R
+++ b/R/structure-level.R
@@ -3,13 +3,13 @@
 #' @description
 #' Glycan structures can have four possible levels of resolution:
 #' - "intact": All monosaccharides are concrete (e.g. "Man", "GlcNAc"),
-#'   and all linkages are fully determined (e.g. "a2-3", "b1-4").
+#'   and no linkage or anomer contains "?".
 #' - "partial": All monosaccharides are concrete (e.g. "Man", "GlcNAc"),
-#'   but some linkage information is missing (e.g. "a2-?").
+#'   at least one linkage or anomer contains "?",
+#'   and at least one linkage or anomer has a non-"?" annotation.
 #' - "topological": All monosaccharides are concrete (e.g. "Man", "GlcNAc"),
-#'   but the linkage information is completely unknown ("??-?").
-#' - "basic": All monosaccharides are generic (e.g. "Hex", "HexNAc"),
-#'   and the linkage information is completely unknown ("??-?").
+#'   and all linkages and anomers are completely unknown ("??-?"/"??").
+#' - "basic": All monosaccharides are generic (e.g. "Hex", "HexNAc").
 #'
 #' Note that in theory you can have a glycan with generic monosaccharides with all linkages determined.
 #' For example, "Hex(b1-3)HexNAc(a1-" is a valid glycan structure.
@@ -19,8 +19,7 @@
 #'
 #' @param x A [glycan_structure()] vector.
 #'
-#' @returns A character vector of the same length as `x`,
-#'   containing the structure level for each element.
+#' @returns A character scalar containing the structure level for `x`.
 #'
 #' @examples
 #' glycan <- as_glycan_structure("Gal(b1-3)GalNAc(a1-")
@@ -31,15 +30,13 @@
 get_structure_level <- function(x) {
   checkmate::assert_class(x, "glyrepr_structure")
 
-  # Capture input names for preservation
-  input_names <- names(x)
-
-  result <- rep(NA_character_, length(x))
   non_na <- !structure_na_mask(x)
 
   if (!any(non_na)) {
-    names(result) <- input_names
-    return(result)
+    if (length(x) == 0) {
+      return(character())
+    }
+    return(NA_character_)
   }
 
   x_valid <- x[non_na]
@@ -47,20 +44,38 @@ get_structure_level <- function(x) {
   has_linkages_strict <- has_linkages(x_valid, strict = TRUE)
   has_linkages_lenient <- has_linkages(x_valid, strict = FALSE)
 
-  result[non_na] <- dplyr::case_when(
-    mono_type == "concrete" & has_linkages_strict ~ "intact",
-    mono_type == "concrete" &
-      (!has_linkages_strict) &
-      has_linkages_lenient ~ "partial",
-    mono_type == "concrete" & (!has_linkages_lenient) ~ "topological",
-    mono_type == "generic" & (!has_linkages_strict) ~ "basic",
-    .default = "basic"
-  )
+  if (mono_type == "generic") {
+    .warn_generic_linkage_structure_level(has_linkages_lenient)
+    return("basic")
+  }
 
-  # Restore names
-  names(result) <- input_names
+  if (all(has_linkages_strict)) {
+    return("intact")
+  }
 
-  result
+  if (any(has_linkages_lenient)) {
+    return("partial")
+  }
+
+  "topological"
+}
+
+#' Warn About Generic Structures With Linkage Annotation
+#'
+#' Generic structures are always treated as basic resolution,
+#' even if they contain linkage or anomer annotations.
+#'
+#' @param has_linkages_lenient A logical vector returned by [has_linkages()]
+#'   with `strict = FALSE`.
+#' @returns Nothing. Called for its warning side effect.
+#' @noRd
+.warn_generic_linkage_structure_level <- function(has_linkages_lenient) {
+  if (any(has_linkages_lenient)) {
+    cli::cli_warn(c(
+      "Generic glycan structures with linkage annotations are treated as {.val basic}.",
+      "i" = "Linkage information is ignored when residues are generic."
+    ), class = "glyrepr_warning_generic_structure_linkages")
+  }
 }
 
 #' Reduce a Glycan Structure to a Lower Resolution Level

--- a/R/structure-level.R
+++ b/R/structure-level.R
@@ -96,10 +96,11 @@ get_structure_level <- function(x) {
 #'
 #' @param x A [glycan_structure()] vector.
 #' @param to_level The resolution level to reduce to. Can be "basic" or "topological".
-#'   Must be a lower resolution level than any structure in `x`
+#'   Must be a lower resolution level than `x`
 #'   ("intact" > "partial" > "topological" > "basic").
-#'   If `to_level` is the same as some structure in `x`, the result will be the same as the input.
-#'   You can use [get_structure_level()] to check the structure levels of `x`.
+#'   If `to_level` is the same as the structure level of `x`,
+#'   the result will be the same as the input.
+#'   You can use [get_structure_level()] to check the structure level of `x`.
 #'
 #' @returns A [glycan_structure()] vector reduced to the given resolution level.
 #' @examples
@@ -112,29 +113,29 @@ reduce_structure_level <- function(x, to_level) {
   checkmate::assert_class(x, "glyrepr_structure")
   checkmate::assert_choice(to_level, c("basic", "topological"))
 
-  # Check if the target level is lower than any structure in `x`
-  struc_levels <- get_structure_level(x)
+  from_level <- get_structure_level(x)
+
+  if (is.na(from_level)) {
+    # Two situations can lead to NA structure level:
+    #. 1. x is empty.
+    #. 2. All structures in x are NA.
+    # In both cases, we can just return x without any modification.
+    return(x)
+  }
+
   level_ranks <- c("basic" = 1, "topological" = 2, "partial" = 3, "intact" = 4)
-  non_na_levels <- struc_levels[!is.na(struc_levels)]
-  from_level_ranks <- level_ranks[non_na_levels]
-  to_level_rank <- level_ranks[to_level]
-  if (any(from_level_ranks < to_level_rank)) {
-    larger_levels <- unique(non_na_levels[from_level_ranks < to_level_rank])
+  if (level_ranks[[from_level]] < level_ranks[[to_level]]) {
     cli::cli_abort(c(
       "Cannot reduce a structure to a higher resolution level.",
-      "x" = "Some structures in {.arg x} have levels: {.val {larger_levels}}.",
-      "i" = "Target level: {.val {to_level}} (> {.val {larger_levels}}).",
-      "i" = "You can use {.fn get_structure_level} to check the structure levels of {.arg x}."
+      "x" = "Structure level of {.arg x}: {.val {from_level}}.",
+      "i" = "Target level: {.val {to_level}} (> {.val {from_level}}).",
+      "i" = "You can use {.fn get_structure_level} to check the structure level of {.arg x}."
     ))
   }
 
-  # Reduce the structure level
+  x <- remove_linkages(x)
   if (to_level == "basic") {
-    x <- remove_linkages(x)
     x <- convert_to_generic(x)
-  } else {
-    # `to_level` is "topological"
-    x <- remove_linkages(x)
   }
   x
 }

--- a/R/structure-level.R
+++ b/R/structure-level.R
@@ -20,6 +20,7 @@
 #' @param x A [glycan_structure()] vector.
 #'
 #' @returns A character scalar containing the structure level for `x`.
+#'   If `x` is empty or all structures in `x` are NA, returns NA_character_.
 #'
 #' @examples
 #' glycan <- as_glycan_structure("Gal(b1-3)GalNAc(a1-")
@@ -34,7 +35,7 @@ get_structure_level <- function(x) {
 
   if (!any(non_na)) {
     if (length(x) == 0) {
-      return(character())
+      return(NA_character_)
     }
     return(NA_character_)
   }

--- a/man/get_structure_level.Rd
+++ b/man/get_structure_level.Rd
@@ -10,20 +10,19 @@ get_structure_level(x)
 \item{x}{A \code{\link[=glycan_structure]{glycan_structure()}} vector.}
 }
 \value{
-A character vector of the same length as \code{x},
-containing the structure level for each element.
+A character scalar containing the structure level for \code{x}.
 }
 \description{
 Glycan structures can have four possible levels of resolution:
 \itemize{
 \item "intact": All monosaccharides are concrete (e.g. "Man", "GlcNAc"),
-and all linkages are fully determined (e.g. "a2-3", "b1-4").
+and no linkage or anomer contains "?".
 \item "partial": All monosaccharides are concrete (e.g. "Man", "GlcNAc"),
-but some linkage information is missing (e.g. "a2-?").
+at least one linkage or anomer contains "?",
+and at least one linkage or anomer has a non-"?" annotation.
 \item "topological": All monosaccharides are concrete (e.g. "Man", "GlcNAc"),
-but the linkage information is completely unknown ("??-?").
-\item "basic": All monosaccharides are generic (e.g. "Hex", "HexNAc"),
-and the linkage information is completely unknown ("??-?").
+and all linkages and anomers are completely unknown ("??-?"/"??").
+\item "basic": All monosaccharides are generic (e.g. "Hex", "HexNAc").
 }
 
 Note that in theory you can have a glycan with generic monosaccharides with all linkages determined.

--- a/man/get_structure_level.Rd
+++ b/man/get_structure_level.Rd
@@ -11,6 +11,7 @@ get_structure_level(x)
 }
 \value{
 A character scalar containing the structure level for \code{x}.
+If \code{x} is empty or all structures in \code{x} are NA, returns NA_character_.
 }
 \description{
 Glycan structures can have four possible levels of resolution:

--- a/man/reduce_structure_level.Rd
+++ b/man/reduce_structure_level.Rd
@@ -10,10 +10,11 @@ reduce_structure_level(x, to_level)
 \item{x}{A \code{\link[=glycan_structure]{glycan_structure()}} vector.}
 
 \item{to_level}{The resolution level to reduce to. Can be "basic" or "topological".
-Must be a lower resolution level than any structure in \code{x}
+Must be a lower resolution level than \code{x}
 ("intact" > "partial" > "topological" > "basic").
-If \code{to_level} is the same as some structure in \code{x}, the result will be the same as the input.
-You can use \code{\link[=get_structure_level]{get_structure_level()}} to check the structure levels of \code{x}.}
+If \code{to_level} is the same as the structure level of \code{x},
+the result will be the same as the input.
+You can use \code{\link[=get_structure_level]{get_structure_level()}} to check the structure level of \code{x}.}
 }
 \value{
 A \code{\link[=glycan_structure]{glycan_structure()}} vector reduced to the given resolution level.

--- a/man/smap.Rd
+++ b/man/smap.Rd
@@ -78,7 +78,7 @@ smap_int(structures, igraph::vcount)
 # Map a function that returns logical
 smap_lgl(structures, function(g) igraph::vcount(g) > 5)
 
-# Use purrr-style lambda functions  
+# Use purrr-style lambda functions
 smap_int(structures, ~ igraph::vcount(.x))
 smap_lgl(structures, ~ igraph::vcount(.x) > 5)
 

--- a/man/spmap.Rd
+++ b/man/spmap.Rd
@@ -87,7 +87,7 @@ weights <- c(1.0, 2.0, 1.0)  # corresponding weights
 factors <- c(2, 3, 2)  # corresponding factors
 
 # Map a function that uses structure, weight, and factor
-spmap_dbl(list(structures, weights, factors), 
+spmap_dbl(list(structures, weights, factors),
           function(g, w, f) igraph::vcount(g) * w * f)
 
 # Use purrr-style lambda functions

--- a/man/structure_to_iupac.Rd
+++ b/man/structure_to_iupac.Rd
@@ -48,7 +48,7 @@ Smaller linkages are placed on the backbone, larger ones in branches.
 # Simple linear structure
 structure_to_iupac(o_glycan_core_1())
 
-# Branched structure  
+# Branched structure
 structure_to_iupac(n_glycan_core())
 
 # Structure with substituents

--- a/tests/testthat/_snaps/structure-level.md
+++ b/tests/testthat/_snaps/structure-level.md
@@ -2,6 +2,10 @@
 
     Code
       res <- get_structure_level(glycans)
+    Condition
+      Warning:
+      Generic glycan structures with linkage annotations are treated as "basic".
+      i Linkage information is ignored when residues are generic.
 
 # reduce_structure_level rejects higher level
 

--- a/tests/testthat/_snaps/structure-level.md
+++ b/tests/testthat/_snaps/structure-level.md
@@ -1,3 +1,8 @@
+# get_structure_level works for a basic glycan vector with linkages
+
+    Code
+      res <- get_structure_level(glycans)
+
 # reduce_structure_level rejects higher level
 
     Code

--- a/tests/testthat/_snaps/structure-level.md
+++ b/tests/testthat/_snaps/structure-level.md
@@ -14,7 +14,7 @@
     Condition
       Error in `reduce_structure_level()`:
       ! Cannot reduce a structure to a higher resolution level.
-      x Some structures in `x` have levels: "basic".
+      x Structure level of `x`: "basic".
       i Target level: "topological" (> "basic").
-      i You can use `get_structure_level()` to check the structure levels of `x`.
+      i You can use `get_structure_level()` to check the structure level of `x`.
 

--- a/tests/testthat/test-smap.R
+++ b/tests/testthat/test-smap.R
@@ -1286,14 +1286,15 @@ test_that("smap_unique documents behavior with named input", {
   expect_true(is.null(names(result)) || startsWith(names(result), "Gal"))
 })
 
-test_that("get_structure_level preserves names", {
+test_that("get_structure_level returns one unnamed level for a named vector", {
   core1 <- o_glycan_core_1()
   core2 <- n_glycan_core()
   structures <- c(core1, core2, core1)
   names(structures) <- c("A", "B", "C")
 
   result <- get_structure_level(structures)
-  expect_equal(names(result), c("A", "B", "C"))
+  expect_equal(result, "intact")
+  expect_null(names(result))
 })
 
 # Tests for NA handling in smap functions -----------------------------------

--- a/tests/testthat/test-structure-level.R
+++ b/tests/testthat/test-structure-level.R
@@ -12,12 +12,64 @@ test_that("get_structure_level works for each glycan separately", {
   expect_equal(get_structure_level(glycan5), "basic")
 })
 
-test_that("get_structure_level works for multiple glycans", {
+test_that("get_structure_level works for an intact glycan vector", {
   glycans <- as_glycan_structure(c(
     "Gal(b1-3)GalNAc(a1-",
     "GalNAc(a1-"
   ))
-  expect_equal(get_structure_level(glycans), c("intact", "intact"))
+  expect_equal(get_structure_level(glycans), "intact")
+})
+
+test_that("get_structure_level works for a partial glycan vector with only one unknown linkage", {
+  glycans <- as_glycan_structure(c(
+    "Gal(b1-?)GalNAc(a1-",
+    "GalNAc(a1-"
+  ))
+  expect_equal(get_structure_level(glycans), "partial")
+})
+
+test_that("get_structure_level works for a partial glycan vector with only one known linkage", {
+  glycans <- as_glycan_structure(c(
+    "Gal(?1-?)GalNAc(??-",
+    "GalNAc(??-"
+  ))
+  expect_equal(get_structure_level(glycans), "partial")
+})
+
+test_that("get_structure_level works for a partial glycan vector with only one known reducing end configuration", {
+  glycans <- as_glycan_structure(c(
+    "Gal(??-?)GalNAc(??-",
+    "GalNAc(?1-"
+  ))
+  expect_equal(get_structure_level(glycans), "partial")
+})
+
+test_that("get_structure_level works for a topological glycan vector", {
+  glycans <- as_glycan_structure(c(
+    "Gal(??-?)GalNAc(??-",
+    "GalNAc(??-"
+  ))
+  expect_equal(get_structure_level(glycans), "topological")
+})
+
+test_that("get_structure_level works for a basic glycan vector", {
+  glycans <- as_glycan_structure(c(
+    "Hex(??-?)HexNAc(??-",
+    "HexNAc(??-"
+  ))
+  expect_equal(get_structure_level(glycans), "basic")
+})
+
+test_that("get_structure_level works for a basic glycan vector with linkages", {
+  glycans <- as_glycan_structure(c(
+    "Hex(b1-3)HexNAc(a1-",
+    "HexNAc(a1-"
+  ))
+  expect_snapshot(res <- get_structure_level(glycans))
+  # should warn about the rare case of a generic glycan with linkages,
+  # and tell the user that it will be treated as basic
+
+  expect_equal(get_structure_level(glycans), "basic")
 })
 
 test_that("reduce_structure_level works for each glycan separately", {

--- a/tests/testthat/test-structure-level.R
+++ b/tests/testthat/test-structure-level.R
@@ -163,3 +163,13 @@ test_that("reduce_structure_level works for multiple glycans", {
     c("Gal(??-?)GalNAc(??-", "Gal(??-?)GalNAc(??-", "Gal(??-?)GalNAc(??-")
   )
 })
+
+test_that("reduce_structure_level works for all-NA vectors", {
+  glycans <- as_glycan_structure(c(NA, NA))
+  expect_equal(reduce_structure_level(glycans, to_level = "topological"), glycans)
+})
+
+test_that("reduce_structure_level works for empty vectors", {
+  glycans <- as_glycan_structure(character())
+  expect_equal(reduce_structure_level(glycans, to_level = "topological"), glycans)
+})

--- a/tests/testthat/test-structure-level.R
+++ b/tests/testthat/test-structure-level.R
@@ -75,6 +75,25 @@ test_that("get_structure_level works for a basic glycan vector with linkages", {
   expect_equal(res, "basic")
 })
 
+test_that("get_structure_level ignores NA", {
+  glycans <- as_glycan_structure(c(
+    "Hex(??-?)HexNAc(??-",
+    "HexNAc(??-",
+    NA
+  ))
+  expect_equal(get_structure_level(glycans), "basic")
+})
+
+test_that("get_structure_level return NA_character_ for all-NA vector", {
+  glycans <- as_glycan_structure(c(NA, NA))
+  expect_equal(get_structure_level(glycans), NA_character_)
+})
+
+test_that("get_structure_level returns NA_character_ for empty vector", {
+  glycans <- as_glycan_structure(character())
+  expect_equal(get_structure_level(glycans), NA_character_)
+})
+
 test_that("reduce_structure_level works for each glycan separately", {
   glycan_intact <- as_glycan_structure("Gal(b1-3)GalNAc(a1-")
   glycan_partial <- as_glycan_structure("Gal(b1-?)GalNAc(a1-")

--- a/tests/testthat/test-structure-level.R
+++ b/tests/testthat/test-structure-level.R
@@ -9,7 +9,10 @@ test_that("get_structure_level works for each glycan separately", {
   expect_equal(get_structure_level(glycan2), "partial")
   expect_equal(get_structure_level(glycan3), "topological")
   expect_equal(get_structure_level(glycan4), "basic")
-  expect_equal(get_structure_level(glycan5), "basic")
+  expect_warning(
+    expect_equal(get_structure_level(glycan5), "basic"),
+    class = "glyrepr_warning_generic_structure_linkages"
+  )
 })
 
 test_that("get_structure_level works for an intact glycan vector", {
@@ -69,7 +72,7 @@ test_that("get_structure_level works for a basic glycan vector with linkages", {
   # should warn about the rare case of a generic glycan with linkages,
   # and tell the user that it will be treated as basic
 
-  expect_equal(get_structure_level(glycans), "basic")
+  expect_equal(res, "basic")
 })
 
 test_that("reduce_structure_level works for each glycan separately", {

--- a/tests/testthat/test-structure.R
+++ b/tests/testthat/test-structure.R
@@ -1337,9 +1337,11 @@ test_that("all glyrepr_structure functions preserve names", {
   # Accessor functions (return atomic vectors)
   expect_equal(names(get_anomer(structures)), c("A", "B", "C"))
   expect_equal(names(has_linkages(structures)), c("A", "B", "C"))
-  expect_equal(names(get_structure_level(structures)), c("A", "B", "C"))
   expect_equal(names(count_mono(structures)), c("A", "B", "C"))
   expect_equal(names(structure_to_iupac(structures)), c("A", "B", "C"))
+
+  # get_structure_level() returns one scalar level for the whole vector.
+  expect_null(names(get_structure_level(structures)))
 
   # Accessor functions (return list)
   expect_equal(names(get_structure_graphs(structures)), c("A", "B", "C"))
@@ -1805,8 +1807,7 @@ test_that("get_structure_level preserves NA structures", {
 
   result <- get_structure_level(structures)
 
-  expect_equal(result[1], "intact")
-  expect_true(is.na(result[2]))
+  expect_equal(result, "intact")
 })
 
 test_that("reduce_structure_level skips NA structures when checking level rank", {

--- a/vignettes/glyrepr.Rmd
+++ b/vignettes/glyrepr.Rmd
@@ -176,16 +176,16 @@ like zoom levels on a map.
 
 - **"intact"**: The full picture — 
   all monosaccharides are concrete (e.g., "Man", "GlcNAc"), 
-  and all linkages are fully determined (e.g., "a2-3", "b1-4").
+  and no linkage or anomer contains "?".
 - **"partial"**: Almost there — 
   all monosaccharides are concrete (e.g., "Man", "GlcNAc"), 
-  but some linkage information is missing (e.g., "a2-?").
+  at least one linkage or anomer contains "?",
+  and at least one linkage or anomer has a non-"?" annotation.
 - **"topological"**: We know what's there, but not how they connect — 
   all monosaccharides are concrete (e.g., "Man", "GlcNAc"), 
-  but the linkage information is completely unknown ("??-?").
+  and all linkages and anomers are completely unknown ("??-?"/"??").
 - **"basic"**: The minimalist view — 
-  all monosaccharides are generic (e.g., "Hex", "HexNAc"), 
-  and the linkage information is completely unknown ("??-?").
+  all monosaccharides are generic (e.g., "Hex", "HexNAc").
 
 💡 **Fun fact**: 
 In theory, you could have a glycan with generic monosaccharides but fully determined linkages 
@@ -194,7 +194,7 @@ But in practice, this is almost unheard of —
 linkage information is much harder to obtain than monosaccharide information. 
 That's why `glyrepr` assigns these structures to the "basic" level too.
 
-You can get the structure level for a glycan structure vector with `get_structure_level()`:
+You can get the vector-wide structure level for a glycan structure vector with `get_structure_level()`:
 
 ```{r}
 # Concrete structures (various linkage detail levels)


### PR DESCRIPTION
## Summary
- Change `get_structure_level()` to return a single resolution level for a `glyrepr_structure` vector instead of one value per element.
- Treat missing structures as ignorable for level inference, while returning `NA_character_` for empty or all-missing vectors.
- Simplify `reduce_structure_level()` around the new scalar level contract and keep generic-with-linkage cases warning-backed.
- Update tests, snapshots, docs, and release notes to reflect the breaking change.

## Testing
- Ran the `structure-level` test file.
- Ran the full `devtools::test()` suite.
- Ran `git diff --check` with no formatting issues.

Closes #37